### PR TITLE
Multiple authors for posts + Meta

### DIFF
--- a/src/Services/textUtilities.ts
+++ b/src/Services/textUtilities.ts
@@ -20,15 +20,5 @@ export function slugify(s: string) {
 }
 
 export function formatPostAuthors(names: string[]) {
-  let res: string = names[0]
-
-  if (names.length > 1) {
-    for (let i = 1; i < names.length - 1; i++) {
-      res += ', ' + names[i]
-    }
-
-    res += ' & ' + names[names.length - 1]
-  }
-
-  return res
+  return names.join(', ').replace(/, (?=[^,]*$)/, ' et ')
 }

--- a/src/Services/textUtilities.ts
+++ b/src/Services/textUtilities.ts
@@ -18,3 +18,17 @@ export function slugify(s: string) {
     .replace(/^-+/, '') // Trim - from start of text
     .replace(/-+$/, '') // Trim - from end of text
 }
+
+export function formatPostAuthors(names: string[]) {
+  let res: string = names[0]
+
+  if (names.length > 1) {
+    for (let i = 1; i < names.length - 1; i++) {
+      res += ', ' + names[i]
+    }
+
+    res += ' & ' + names[names.length - 1]
+  }
+
+  return res
+}

--- a/src/components/IdeaContent.tsx
+++ b/src/components/IdeaContent.tsx
@@ -7,6 +7,7 @@ import AccessTime from '../static/icons/access_time-24px.svg'
 import Back from '../static/icons/Btn_Retour.svg'
 import Link from 'next/link'
 import Button from './Button'
+import { formatPostAuthors } from '../Services/textUtilities'
 
 interface Props {
   content: IdeasContent
@@ -28,9 +29,7 @@ function IdeaContent({ content }: Props) {
               <span className="pr-1">
                 {content.date.slice(8, 10)}/{content.date.slice(5, 7)}/{content.date.slice(0, 4)}
               </span>
-              <span className="text-blue">
-                | {`${content.author}`} {content.coAuthor && ` & ${content.coAuthor}`}
-              </span>
+              <span className="text-blue">| {`${formatPostAuthors(content.authors)}`}</span>
             </span>
             <span className="flex items-center">
               <img src={AccessTime} style={{ width: 15, height: 15 }} alt="read_time" />

--- a/src/models/IdeasAPI.ts
+++ b/src/models/IdeasAPI.ts
@@ -6,7 +6,7 @@ export interface PostAPI {
   acf: {
     idea_image: string
     idea_description: string
-    coAuthor: { data: { display_name: string } }
+    coAuthor: [{ data: { display_name: string } }]
   }
   _embedded: {
     'wp:term': [

--- a/src/types/IdeasContent.ts
+++ b/src/types/IdeasContent.ts
@@ -34,8 +34,7 @@ export interface IdeasPageContent {
 export default interface IdeasContent {
   title: string
   date: string
-  author: string
-  coAuthor: string
+  authors: string[]
   content: string
   imageUrl: string
   category: string


### PR DESCRIPTION
⚠ Si rollback, changer le type de champ co_author sur WP => désactiver les valeurs multiples